### PR TITLE
Rename SearchQuery builder methods

### DIFF
--- a/src/main/java/org/jboss/processing/NewIssueCollector.java
+++ b/src/main/java/org/jboss/processing/NewIssueCollector.java
@@ -31,7 +31,7 @@ public class NewIssueCollector extends NewIssuesConsumer implements Executable<E
     }
 
     public static NewIssueCollector getInstance(JiraEndpoint jiraEndpoint) {
-        SearchQuery searchQuery = SearchQuery.builder().setProjects("WFLY").setStatus(IssueStatus.NEW).setAssigneeEmpty()
+        SearchQuery searchQuery = SearchQuery.builder().projects("WFLY").status(IssueStatus.NEW).assigneeEmpty()
                 .build();
         jiraEndpoint.setJql(JqlBuilder.build(searchQuery));
         return new NewIssueCollector(jiraEndpoint);

--- a/src/main/java/org/jboss/processing/StaleIssueCollector.java
+++ b/src/main/java/org/jboss/processing/StaleIssueCollector.java
@@ -31,9 +31,9 @@ public class StaleIssueCollector extends NewIssuesConsumer implements Executable
     }
 
     public static StaleIssueCollector getInstance(JiraEndpoint jiraEndpoint) {
-        // TODO add stale period for SearchBuilder.setEndDate
-        SearchQuery searchQuery = SearchQuery.builder().setProjects("WFLY").setAssigneeNotEmpty()
-                .setStatus(IssueStatus.CREATED, IssueStatus.ASSIGNED, IssueStatus.POST).build();
+        // TODO add stale period for SearchBuilder.endDate
+        SearchQuery searchQuery = SearchQuery.builder().projects("WFLY").assigneeNotEmpty()
+                .status(IssueStatus.CREATED, IssueStatus.ASSIGNED, IssueStatus.POST).build();
         jiraEndpoint.setJql(JqlBuilder.build(searchQuery));
         return new StaleIssueCollector(jiraEndpoint);
     }

--- a/src/main/java/org/jboss/query/SearchQuery.java
+++ b/src/main/java/org/jboss/query/SearchQuery.java
@@ -99,52 +99,52 @@ public class SearchQuery {
         private Builder() {
         }
 
-        public Builder setStatus(IssueStatus status, IssueStatus... statuses) {
+        public Builder status(IssueStatus status, IssueStatus... statuses) {
             this.statuses = Stream.concat(Stream.of(status), Stream.of(statuses)).toList();
             return this;
         }
 
-        public Builder setAssigneeNotEmpty() {
+        public Builder assigneeNotEmpty() {
             this.assignee = NOT_EMPTY;
             return this;
         }
 
-        public Builder setAssigneeEmpty() {
+        public Builder assigneeEmpty() {
             this.assignee = EMPTY_ASSIGNEE;
             return this;
         }
 
-        public Builder setAssignee(String assignee) {
+        public Builder assignee(String assignee) {
             this.assignee = assignee;
             return this;
         }
 
-        public Builder setProjects(String project, String... projects) {
+        public Builder projects(String project, String... projects) {
             this.projects = Stream.concat(Stream.of(project), Stream.of(projects)).toList();
             return this;
         }
 
-        public Builder setComponents(String component, String... components) {
+        public Builder components(String component, String... components) {
             this.components = Stream.concat(Stream.of(component), Stream.of(components)).toList();
             return this;
         }
 
-        public Builder setStartDate(LocalDate startDate) {
+        public Builder startDate(LocalDate startDate) {
             this.startDate = startDate;
             return this;
         }
 
-        public Builder setEndDate(LocalDate endDate) {
+        public Builder endDate(LocalDate endDate) {
             this.endDate = endDate;
             return this;
         }
 
-        public Builder setMaxResults(Integer maxResults) {
+        public Builder maxResults(Integer maxResults) {
             this.maxResults = maxResults;
             return this;
         }
 
-        public Builder setLabels(String label, String... labels) {
+        public Builder labels(String label, String... labels) {
             this.labels = Stream.concat(Stream.of(label), Stream.of(labels)).collect(Collectors.toSet());
             return this;
         }

--- a/src/test/java/org/jboss/set/jql/JqlFromSearchQueryTest.java
+++ b/src/test/java/org/jboss/set/jql/JqlFromSearchQueryTest.java
@@ -14,21 +14,21 @@ public class JqlFromSearchQueryTest {
 
     @Test
     void onlyAssigneeQueryTest() {
-        searchQuery = SearchQuery.builder().setAssignee("Tadpole").build();
+        searchQuery = SearchQuery.builder().assignee("Tadpole").build();
         Assertions.assertEquals("assignee = 'Tadpole'", JqlBuilder.build(searchQuery));
     }
 
     @Test
     void onlyProjectQueryTest() {
-        searchQuery = SearchQuery.builder().setProjects("WFLY", "RESTEASY", "WFCORE").build();
+        searchQuery = SearchQuery.builder().projects("WFLY", "RESTEASY", "WFCORE").build();
         Assertions.assertEquals("project IN ('WFLY', 'RESTEASY', 'WFCORE')", JqlBuilder.build(searchQuery));
     }
 
     @Test
     void assigneeAndProjectQueryTest() {
         searchQuery = SearchQuery.builder()
-                .setAssignee("Tadpole")
-                .setProjects("WFLY", "RESTEASY", "WFCORE")
+                .assignee("Tadpole")
+                .projects("WFLY", "RESTEASY", "WFCORE")
                 .build();
         Assertions.assertEquals("assignee = 'Tadpole' AND project IN ('WFLY', 'RESTEASY', 'WFCORE')",
                 JqlBuilder.build(searchQuery));
@@ -37,8 +37,8 @@ public class JqlFromSearchQueryTest {
     @Test
     void ProjectAndComponentQueryTest() {
         searchQuery = SearchQuery.builder()
-                .setProjects("WFLY", "RESTEASY", "WFCORE")
-                .setComponents("Documentation")
+                .projects("WFLY", "RESTEASY", "WFCORE")
+                .components("Documentation")
                 .build();
         Assertions.assertEquals("component IN ('Documentation') AND project IN ('WFLY', 'RESTEASY', 'WFCORE')",
                 JqlBuilder.build(searchQuery));
@@ -47,9 +47,9 @@ public class JqlFromSearchQueryTest {
     @Test
     void assigneeAndProjectAndComponentQueryTest() {
         searchQuery = SearchQuery.builder()
-                .setAssignee("Tadpole")
-                .setProjects("WFLY", "RESTEASY", "WFCORE")
-                .setComponents("Documentation")
+                .assignee("Tadpole")
+                .projects("WFLY", "RESTEASY", "WFCORE")
+                .components("Documentation")
                 .build();
         Assertions.assertEquals(
                 "assignee = 'Tadpole' AND component IN ('Documentation') AND project IN ('WFLY', 'RESTEASY', 'WFCORE')",
@@ -59,8 +59,8 @@ public class JqlFromSearchQueryTest {
     @Test
     void notEmptyAssigneeAndMultipleStatusesQueryTest() {
         searchQuery = SearchQuery.builder()
-                .setAssigneeNotEmpty()
-                .setStatus(IssueStatus.CREATED, IssueStatus.ON_QA, IssueStatus.POST)
+                .assigneeNotEmpty()
+                .status(IssueStatus.CREATED, IssueStatus.ON_QA, IssueStatus.POST)
                 .build();
         Assertions.assertEquals("status IN ('new', 'ready for qa', 'pull request sent') AND assignee IS NOT EMPTY",
                 JqlBuilder.build(searchQuery));
@@ -68,7 +68,7 @@ public class JqlFromSearchQueryTest {
 
     @Test
     void assigneeEmptyQueryTest() {
-        searchQuery = SearchQuery.builder().setAssigneeEmpty().build();
+        searchQuery = SearchQuery.builder().assigneeEmpty().build();
         Assertions.assertEquals("assignee IS EMPTY", JqlBuilder.build(searchQuery));
     }
 }

--- a/src/test/java/org/jboss/set/jql/SearchQueryTest.java
+++ b/src/test/java/org/jboss/set/jql/SearchQueryTest.java
@@ -30,14 +30,14 @@ public class SearchQueryTest {
 
     @Test
     void createSimpleSearchQueryWithoutCollectionsTest() {
-        testEmptyGetters(SearchQuery.builder().setAssignee("Tadpole").setStatus(IssueStatus.NEW).setMaxResults(20).build(),
+        testEmptyGetters(SearchQuery.builder().assignee("Tadpole").status(IssueStatus.NEW).maxResults(20).build(),
                 QueryParameter.getAssignee, QueryParameter.getStatus, QueryParameter.getMaxResults);
     }
 
     @Test
     void createSearchQueryWithCollectionsTest() {
-        SearchQuery searchQuery = SearchQuery.builder().setProjects("WFLY", "RESTEASY", "JBEAP")
-                .setComponents("Localization", "Documentation").build();
+        SearchQuery searchQuery = SearchQuery.builder().projects("WFLY", "RESTEASY", "JBEAP")
+                .components("Localization", "Documentation").build();
         testEmptyGetters(searchQuery, QueryParameter.getProjects, QueryParameter.getComponents);
         searchQuery.getProjects().ifPresent(projects -> Assertions.assertEquals(3, projects.size()));
         searchQuery.getComponents().ifPresent(components -> Assertions.assertEquals(2, components.size()));
@@ -45,7 +45,7 @@ public class SearchQueryTest {
 
     @Test
     void createSearchQueryWithEmptyAssigneeTest() {
-        SearchQuery searchQuery = SearchQuery.builder().setAssigneeEmpty().build();
+        SearchQuery searchQuery = SearchQuery.builder().assigneeEmpty().build();
         testEmptyGetters(searchQuery, QueryParameter.getAssignee);
         Assertions.assertTrue(searchQuery.isAssigneeEmpty());
     }


### PR DESCRIPTION
The enum part mentioned from #17 is not relevant